### PR TITLE
layout: with default implementation

### DIFF
--- a/layout.go
+++ b/layout.go
@@ -1,0 +1,39 @@
+package irutil
+
+import (
+	"fmt"
+
+	"github.com/llir/llvm/ir/types"
+)
+
+// Layout provides configuration about metadata of compiler
+type Layout interface {
+	SizeOf(typ types.Type) int
+}
+
+// DefaultLayout provides a default implementation for size of type, you should create your owned implementation by embedding this structure, and call SizeOf by default
+type DefaultLayout struct{}
+
+// SizeOf returns size of types.Type, value is how many bits
+func (l DefaultLayout) SizeOf(typ types.Type) int {
+	switch typ := typ.(type) {
+	case *types.IntType:
+		return int(typ.BitSize)
+	case *types.FloatType:
+		switch typ.Kind {
+		case types.FloatKindHalf:
+			return 16
+		case types.FloatKindFloat:
+			return 32
+		case types.FloatKindDouble:
+			return 64
+		case types.FloatKindFP128:
+			return 128
+		case types.FloatKindX86_FP80:
+			return 80
+		case types.FloatKindPPC_FP128:
+			return 128
+		}
+	}
+	panic(fmt.Sprintf("unimplemented size of this type, %v", typ))
+}

--- a/layout.go
+++ b/layout.go
@@ -6,15 +6,18 @@ import (
 	"github.com/llir/llvm/ir/types"
 )
 
-// Layout provides configuration about metadata of compiler
+// Layout specifies how data is to be laid out in memory.
 type Layout interface {
+	// SizeOf returns the size of the given type in number of bits.
 	SizeOf(typ types.Type) int
 }
 
-// DefaultLayout provides a default implementation for size of type, you should create your owned implementation by embedding this structure, and call SizeOf by default
+// DefaultLayout provides a default implementation of data layout, which specifies the size of types and how data is to be laid out in memory.
+//
+// Users may embed this struct and implement the Sizeof method to provide custom handling of specific types and their size in number of bits.
 type DefaultLayout struct{}
 
-// SizeOf returns size of types.Type, value is how many bits
+// SizeOf returns the size of the given type in number of bits.
 func (l DefaultLayout) SizeOf(typ types.Type) int {
 	switch typ := typ.(type) {
 	case *types.IntType:

--- a/layout.go
+++ b/layout.go
@@ -36,6 +36,8 @@ func (l DefaultLayout) SizeOf(typ types.Type) int {
 			return 80
 		case types.FloatKindPPC_FP128:
 			return 128
+		default:
+			panic(fmt.Errorf("support for size of on floating-point type of kind %v not yet implemented", typ.Kind))
 		}
 	}
 	panic(fmt.Errorf("support for size of on type %T not yet implemented", typ))

--- a/layout.go
+++ b/layout.go
@@ -35,5 +35,5 @@ func (l DefaultLayout) SizeOf(typ types.Type) int {
 			return 128
 		}
 	}
-	panic(fmt.Sprintf("unimplemented size of this type, %v", typ))
+	panic(fmt.Errorf("support for size of on type %T not yet implemented", typ))
 }


### PR DESCRIPTION
llir/llvm#66

### Usage

```go
type MyLayout struct {
    irutil.DefaultLayout
}

func (l MyLayout) SizeOf(typ types.Type) int {
    switch typ.(type) {
    // case: ...
    }
    return l.DefaultLayout.SizeOf(typ)
}
```